### PR TITLE
修复文档包含Python注释代码块时，生成页内目录异常的bug

### DIFF
--- a/lib/pageCatalogue.js
+++ b/lib/pageCatalogue.js
@@ -19,6 +19,7 @@ const pageCatalogue = (function () {
          * @private
          */
         _extract: function (arc) {
+            arc = arc.replace(/(```[\s\S\D]*?```)/g,'');
             let lines = arc.split('\n');
             if (lines.length === 1) {
                 lines = lines[0].split('\r');


### PR DESCRIPTION
这个是我在使用amWiki插件时遇到的问题，如下图所示：
![image](https://user-images.githubusercontent.com/14124918/37862576-3993595e-2f8a-11e8-811e-c295fd4020d8.png)

这个PR是我的修复方案：只需在分割页内目录之前，用正则表达式将当前文档的所有markdown的代码块干掉就可以了